### PR TITLE
Add support for Abstraction data types in enter_block()

### DIFF
--- a/lib/analysis.pi
+++ b/lib/analysis.pi
@@ -2,6 +2,8 @@
 <define ARRAY_TYPES NULL/>
 
 
+<code AbstractionDataType pars=(varDecls) symtab="" />
+
 <code BookKeeping pars=(content)> @content@ </code>
 
 <xform insert_typeInfo pars=(type,vars) tab=GLOBAL.SymTable/>

--- a/lib/analysis.pi
+++ b/lib/analysis.pi
@@ -2,7 +2,7 @@
 <define ARRAY_TYPES NULL/>
 
 
-<code AbstractionDataType pars=(varDecls) symtab="" />
+<code AbstractionBlock pars=(varDecls) symtab="" />
 
 <code BookKeeping pars=(content)> @content@ </code>
 

--- a/lib/analysis.pt
+++ b/lib/analysis.pt
@@ -7,7 +7,7 @@ include analysis.pi
    case CODE.FunctionDecl: newtab=block[FunctionDecl.symtab];
    case CODE.StmtBlock: newtab=block[StmtBlock.symtab];
    case CODE.DeclarationBlock: newtab=block[DeclarationBlock.symtab];
-   case CODE.AbstractionDataType: newtab=block[AbstractionDataType.symtab];
+   case CODE.Abstraction: newtab=block[Abstraction.symtab];
    case CODE.ClassBody: newtab=block[ClassBody.symtab];
    case CODE.TemplateDecl#(_,d) : return enter_block(d);
    case CODE.Constructor : newtab = block[Constructor.symtab];

--- a/lib/analysis.pt
+++ b/lib/analysis.pt
@@ -7,7 +7,7 @@ include analysis.pi
    case CODE.FunctionDecl: newtab=block[FunctionDecl.symtab];
    case CODE.StmtBlock: newtab=block[StmtBlock.symtab];
    case CODE.DeclarationBlock: newtab=block[DeclarationBlock.symtab];
-   case CODE.Abstraction: newtab=block[Abstraction.symtab];
+   case CODE.AbstractionBlock: newtab=block[AbstractionBlock.symtab];
    case CODE.ClassBody: newtab=block[ClassBody.symtab];
    case CODE.TemplateDecl#(_,d) : return enter_block(d);
    case CODE.Constructor : newtab = block[Constructor.symtab];

--- a/lib/analysis.pt
+++ b/lib/analysis.pt
@@ -11,6 +11,7 @@ include analysis.pi
    case CODE.ClassBody: newtab=block[ClassBody.symtab];
    case CODE.TemplateDecl#(_,d) : return enter_block(d);
    case CODE.Constructor : newtab = block[Constructor.symtab];
+   case MAP : newtab = block;
    case "NEW": newtab=MAP{}; 
    }
    GLOBAL.SymTable=newtab :: tab;

--- a/lib/analysis.pt
+++ b/lib/analysis.pt
@@ -7,6 +7,7 @@ include analysis.pi
    case CODE.FunctionDecl: newtab=block[FunctionDecl.symtab];
    case CODE.StmtBlock: newtab=block[StmtBlock.symtab];
    case CODE.DeclarationBlock: newtab=block[DeclarationBlock.symtab];
+   case CODE.AbstractionDataType: newtab=block[AbstractionDataType.symtab];
    case CODE.ClassBody: newtab=block[ClassBody.symtab];
    case CODE.TemplateDecl#(_,d) : return enter_block(d);
    case CODE.Constructor : newtab = block[Constructor.symtab];
@@ -77,7 +78,7 @@ switch (vars)
         (type,vars)
  case CODE.FunctionPtr#(name) : tab[name]=type; (type,vars)
  case ""|NULL : (type,NULL)
- case CODE.Uop|CODE.TypeName|CODE.EnumType|CODE.DeclarationBlock|CODE.UnionType|CODE.RegisterType|CODE.FloatType|CODE.VoidType|CODE.StaticType|CODE.VolatileType|CODE.InlineType|CODE.ConstType|CODE.IntType|CODE.IntType1|CODE.Comment|CODE.BookKeeping|CODE.EmptyStmt|CODE.Macro|CODE.AtomicModify|CODE.Return|CODE.AccessControl|CODE.FriendDecl|CODE.ExpStmt|CODE.Nest|CODE.StmtBlock|CODE.SwitchStmt : vars
+ case CODE.Uop|CODE.TypeName|CODE.EnumType|CODE.DeclarationBlock|CODE.AbstractionDataType|CODE.UnionType|CODE.RegisterType|CODE.FloatType|CODE.VoidType|CODE.StaticType|CODE.VolatileType|CODE.InlineType|CODE.ConstType|CODE.IntType|CODE.IntType1|CODE.Comment|CODE.BookKeeping|CODE.EmptyStmt|CODE.Macro|CODE.AtomicModify|CODE.Return|CODE.AccessControl|CODE.FriendDecl|CODE.ExpStmt|CODE.Nest|CODE.StmtBlock|CODE.SwitchStmt : vars
 }
 
 </xform>

--- a/lib/analysis.pt
+++ b/lib/analysis.pt
@@ -78,7 +78,7 @@ switch (vars)
         (type,vars)
  case CODE.FunctionPtr#(name) : tab[name]=type; (type,vars)
  case ""|NULL : (type,NULL)
- case CODE.Uop|CODE.TypeName|CODE.EnumType|CODE.DeclarationBlock|CODE.AbstractionDataType|CODE.UnionType|CODE.RegisterType|CODE.FloatType|CODE.VoidType|CODE.StaticType|CODE.VolatileType|CODE.InlineType|CODE.ConstType|CODE.IntType|CODE.IntType1|CODE.Comment|CODE.BookKeeping|CODE.EmptyStmt|CODE.Macro|CODE.AtomicModify|CODE.Return|CODE.AccessControl|CODE.FriendDecl|CODE.ExpStmt|CODE.Nest|CODE.StmtBlock|CODE.SwitchStmt : vars
+ case CODE.Uop|CODE.TypeName|CODE.EnumType|CODE.DeclarationBlock|CODE.UnionType|CODE.RegisterType|CODE.FloatType|CODE.VoidType|CODE.StaticType|CODE.VolatileType|CODE.InlineType|CODE.ConstType|CODE.IntType|CODE.IntType1|CODE.Comment|CODE.BookKeeping|CODE.EmptyStmt|CODE.Macro|CODE.AtomicModify|CODE.Return|CODE.AccessControl|CODE.FriendDecl|CODE.ExpStmt|CODE.Nest|CODE.StmtBlock|CODE.SwitchStmt : vars
 }
 
 </xform>


### PR DESCRIPTION
Define a new block to specify Abstraction data types and configure enter_block() to recognize the block. 