### PR TITLE
Fix for StructType, Continue, and ExpBlock when calling xform.global_modread

### DIFF
--- a/lib/analysis.pi
+++ b/lib/analysis.pi
@@ -12,6 +12,12 @@
 
 <xform exit_block pars=(block) tab=GLOBAL.SymTable/>
 
+<xform get_scope pars=(exp) tab=GLOBAL.SymTable/>
+
+<xform get_extra_info pars=(variable, tag) tab=GLOBAL.SymTable/>
+
+<xform set_extra_info pars=(variable, info, tag) tab=GLOBAL.SymTable/>
+
 <xform get_type pars=(exp) tab=GLOBAL.SymTable/>
 
 <xform global_modread pars=(op) local_vars="" output=(_mod,_read) />
@@ -64,4 +70,3 @@
 
 <* return whether exp is linked by an unknown node in edges *>
 <xform is_linked_by_unknown pars=(exp, graphs) /> 
-

--- a/lib/analysis.pi
+++ b/lib/analysis.pi
@@ -22,6 +22,8 @@
 
 <xform global_modread pars=(op) local_vars="" output=(_mod,_read) />
 
+<xform collect_all_moderead pars=(op) output=(_mod,_read) />
+
 <* collect all dereferences of ptr that may be modified *>
 <xform collect_ptr_mod pars=(ptr,block) />
 

--- a/lib/analysis.pt
+++ b/lib/analysis.pt
@@ -271,6 +271,34 @@ switch (vars)
    }
 </xform>
 
+<xform collect_all_mod pars=(op) >
+  switch (op) {
+    case CODE.Assign#(lhs, _) | CODE.Uop#("--"|"++",lhs)
+       | CODE.VarRef#(lhs,"++"|"--") | CODE.DeleteStmt#(lhs) : lhs
+    case INT|CODE.Break | CODE.EmptyStmt | NULL | CODE.True | CODE.False |
+         CODE.VariableParse | ID | CODE.Name |
+         CODE.PtrAccess | CODE.ArrayAccess | CODE.Bop | CODE.Uop: NULL
+    <<*collect decleared variables that are also initialized*>
+    case CODE.DeclStmt:
+        res = NULL;
+        foreach (op : CODE.TypeInfo#(t=_,n=_,init=_) : TRUE) {
+           if (!(init : NULL|""))
+              res = n :: res;
+         }
+         res
+    case CODE.FunctionCall#("memset"|"memcpy"|"memmove"|ScopedName#("std" "memset"|"memcpy"|"memmove"),args): car(args)
+    case CODE.FunctionCall#("assert"|CODE.ScopedName#("std" "make_pair"),_) : NULL
+    case CODE.impl_variant#(_,_,block) : collect_all_mod(car block)
+    case CODE.VEC#(name,_,_,_,_) : name
+    case Nest#(first, second)|CODE.CastExp#(first,second)|(first second) : AppendList[erase_replicate=1](collect_all_mod(first), collect_all_mod(second))
+    case If#(exp) : collect_all_mod(exp)
+    <<* cases that were returning "___UNKNOWN___" in collect_mod*>
+    case STRING|CODE.Break|CODE.EmptyStmt|CODE.SizeOf|CODE.String|CODE.ObjAccess|CODE.PtrAccess|CODE.ArrayAccess|CODE.IntType|CODE.IntType1|CODE.PtrType|INT|CODE.INT_UL|CODE.INT_0x|FLOAT|CODE.True|CODE.False
+    |CODE.GotoStmt|CODE.Char|CODE.Return|CODE.Continue|CODE.LabelStmt|"": NULL
+    case CODE.FunctionCall#(name,args): collect_all_mod(args)
+   }
+</xform>
+
 <xform collect_global_read pars=(op) local_vars="">
   switch (op) {
      case  CODE.FunctionCall#(_,rhs) | CODE.FunctionCallParameter#(rhs) | CODE.VarConstructor#rhs | DeleteStmt#(rhs) |
@@ -334,9 +362,31 @@ switch (vars)
         if (rest != NULL) (m2=_,r2=_)=global_modread(rest);
         else m2=r2=NULL;
         (AppendList[erase_replicate=1](m1,m2),AppendList[erase_replicate=1](r1,r2))
-    case CODE.Else|CODE.Macro|"" : (NULL,NULL)
+    case CODE.Else|"" : (NULL,NULL)
     case CODE.impl_variant#(_,_,s) : global_modread(car s)
     default: (collect_mod(op),collect_global_read[local_vars=local_vars](op))
+  }
+</xform>
+
+<xform collect_all_moderead pars=(op) output=(_mod,_read) >
+  switch (op) {
+    case CODE.FunctionDecl#(cur_name,params, rtype, body): collect_all_moderead(body)
+    case CODE.StmtBlock#s | CODE.ExpStmt#s | CODE.Return#s | CODE.If#(s) | CODE.Else#(s=CODE.If,_) | CODE.While#(s) :
+         collect_all_moderead(s);
+    case (first rest) | CODE.Nest#(first,rest) | CODE.For#(first,rest,_):
+        (m1,r1)=collect_all_moderead(first);
+        if (rest != NULL) (m2=_,r2=_)=collect_all_moderead(rest);
+        else m2=r2=NULL;
+        (AppendList[erase_replicate=1](m1,m2),AppendList[erase_replicate=1](r1,r2))
+    case  CODE.Loop#(name,start,stop,step) | CODE.Loop_r#(name,start,stop,step) :
+        (m1,r1)=collect_all_moderead(name);
+        (m2,r2)=collect_all_moderead(start);
+        (m3,r3)=collect_all_moderead(stop);
+        (m4,r4)=collect_all_moderead(step);
+        (AppendList[erase_replicate=1](m1::m2,m3::m4),AppendList[erase_replicate=1](r1::r2,r3::r4))
+    case CODE.Else|"" : (NULL,NULL)
+    case CODE.impl_variant#(_,_,s) : collect_all_moderead(car s)
+    default: (collect_all_mod(op),collect_global_read(op))
   }
 </xform>
 

--- a/lib/analysis.pt
+++ b/lib/analysis.pt
@@ -242,7 +242,7 @@ switch (vars)
            CODE.Uop#("!"|"*"|"++"|"--"|"&",rhs) | CODE.VarRef#(rhs,"++"|"--"):
          collect_global_read(rhs)
      case CODE.PtrAccess#(rhs=_,_) | CODE.Bop#(".",rhs=_,_) | CODE.Uop#("*",rhs=_)
-         | CODE.ObjAccess#(rhs=_,_)  | CODE.ArrayAccess#(_,rhs=_) | CODE.Uop#(_,rhs=_):
+         | CODE.ObjAccess#(rhs=_,_)  | CODE.ArrayAccess#(_,rhs=_) | CODE.Uop#(_,rhs=_) | CODE.StructType#(_,rhs=_):
          BuildList(collect_global_read(rhs), op)
      case CODE.Assign#(op1,op2):
          switch (op1) {
@@ -255,8 +255,8 @@ switch (vars)
          | (op1,op2) | (op1 op2) | CODE.FunctionParameterDecl#(op1,op2):
        BuildList(collect_global_read(op1), collect_global_read(op2))
     case ID|CODE.Name|CODE.ScopedName: if (Lookup(op, local_vars)) { "" } else {op}
-    case STRING|CODE.Break|CODE.EmptyStmt|CODE.SizeOf|CODE.String|INT|CODE.INT_UL|FLOAT|CODE.True|CODE.False|CODE.GotoStmt|CODE.Char|"": ""
-    case CODE.DeclStmt#d :
+    case STRING|CODE.Break|CODE.EmptyStmt|CODE.SizeOf|CODE.String|INT|CODE.INT_UL|FLOAT|CODE.True|CODE.False|CODE.GotoStmt|CODE.Char|CODE.Continue|"": ""
+    case CODE.DeclStmt#d|CODE.ExpBlock#d :
          if (car(d) : CODE.TypeInfo) { collect_global_read(d) } else { "" }
     case CODE.ArrayInit|CODE.TypeName|CODE.TemplateInstantiation|NULL: NULL
     case CODE.impl_variant#(_,_,block) : collect_global_read(car block)

--- a/lib/analysis.pt
+++ b/lib/analysis.pt
@@ -242,7 +242,7 @@ switch (vars)
            CODE.Uop#("!"|"*"|"++"|"--"|"&",rhs) | CODE.VarRef#(rhs,"++"|"--"):
          collect_global_read(rhs)
      case CODE.PtrAccess#(rhs=_,_) | CODE.Bop#(".",rhs=_,_) | CODE.Uop#("*",rhs=_)
-         | CODE.ObjAccess#(rhs=_,_)  | CODE.ArrayAccess#(_,rhs=_) | CODE.Uop#(_,rhs=_) | CODE.StructType#(_,rhs=_):
+         | CODE.ObjAccess#(rhs=_,_)  | CODE.ArrayAccess#(_,rhs=_) | CODE.Uop#(_,rhs=_):
          BuildList(collect_global_read(rhs), op)
      case CODE.Assign#(op1,op2):
          switch (op1) {
@@ -256,9 +256,10 @@ switch (vars)
        BuildList(collect_global_read(op1), collect_global_read(op2))
     case ID|CODE.Name|CODE.ScopedName: if (Lookup(op, local_vars)) { "" } else {op}
     case STRING|CODE.Break|CODE.EmptyStmt|CODE.SizeOf|CODE.String|INT|CODE.INT_UL|FLOAT|CODE.True|CODE.False|CODE.GotoStmt|CODE.Char|CODE.Continue|"": ""
-    case CODE.DeclStmt#d|CODE.ExpBlock#d :
+    case CODE.ExpBlock#d : collect_global_read(d);
+    case CODE.DeclStmt#d :
          if (car(d) : CODE.TypeInfo) { collect_global_read(d) } else { "" }
-    case CODE.ArrayInit|CODE.TypeName|CODE.TemplateInstantiation|NULL: NULL
+    case CODE.ArrayInit|CODE.TypeName|CODE.TemplateInstantiation|CODE.StructType|NULL: NULL
     case CODE.impl_variant#(_,_,block) : collect_global_read(car block)
     case CODE.VEC#(name,_,_,_,_) : name
    }

--- a/lib/analysis.pt
+++ b/lib/analysis.pt
@@ -27,6 +27,18 @@ include analysis.pi
    res
 </xform>
 
+<xform get_scope pars=(exp) tab=GLOBAL.SymTable>
+  res = "";
+  for (p = tab; p != NULL; p = cdr(p)){
+    if (car(p) != ""){
+      if ((car(p))[exp] != ""){
+        res = car(p);
+      }
+    }
+  }
+  return res;
+</xform>
+
 <xform insert_typeInfo pars=(type,vars) gtab=GLOBAL.SymTable>
 if (gtab == NULL) { GLOBAL.SymTable=gtab=MAP{}; }
 tab = car(gtab);
@@ -170,6 +182,31 @@ switch (vars)
   }
 </xform>
 
+<xform get_extra_info pars=(variable, tag) tab=GLOBAL.SymTable>
+  scope = get_scope(variable);
+  assert(scope != "");
+  if(scope[tag] == ""){
+    return "";
+  }else{
+    extra = scope[tag];
+    return extra[variable];
+  }
+</xform>
+
+<xform set_extra_info pars=(variable, info, tag) tab=GLOBAL.SymTable>
+  scope = get_scope(variable);
+  assert(scope != "");
+  if(scope[tag] == ""){
+    extra = MAP{};
+    scope[tag] = extra;
+  }
+  extra = scope[tag];
+  if(extra[variable] == ""){
+    extra[variable] = info;
+  }else{
+    extra[variable] =  info :: extra[variable];
+  }
+</xform>
 
 <*******************************************************>
 <xform member_variables pars=(input)>
@@ -255,11 +292,11 @@ switch (vars)
          | (op1,op2) | (op1 op2) | CODE.FunctionParameterDecl#(op1,op2):
        BuildList(collect_global_read(op1), collect_global_read(op2))
     case ID|CODE.Name|CODE.ScopedName: if (Lookup(op, local_vars)) { "" } else {op}
-    case STRING|CODE.Break|CODE.EmptyStmt|CODE.SizeOf|CODE.String|INT|CODE.INT_UL|FLOAT|CODE.True|CODE.False|CODE.GotoStmt|CODE.Char|CODE.Continue|"": ""
-    case CODE.ExpBlock#d : collect_global_read(d);
+    case STRING|CODE.Break|CODE.EmptyStmt|CODE.SizeOf|CODE.String|INT|CODE.INT_UL|FLOAT|CODE.True|CODE.False|CODE.GotoStmt|CODE.Char|CODE.Continue|CODE.LabelStmt|"": ""
+    case CODE.ExpBlock#d: collect_global_read(d);
     case CODE.DeclStmt#d :
          if (car(d) : CODE.TypeInfo) { collect_global_read(d) } else { "" }
-    case CODE.ArrayInit|CODE.TypeName|CODE.TemplateInstantiation|CODE.StructType|NULL: NULL
+    case CODE.ArrayInit|CODE.TypeName|CODE.TemplateInstantiation|CODE.StructType|CODE.FunctionDecl|NULL: NULL
     case CODE.impl_variant#(_,_,block) : collect_global_read(car block)
     case CODE.VEC#(name,_,_,_,_) : name
    }
@@ -289,15 +326,15 @@ switch (vars)
 <xform global_modread pars=(op) local_vars="" output=(_mod,_read) >
   switch (op) {
     case CODE.FunctionDecl#(cur_name,params, rtype, body): global_modread(body)
-    case CODE.StmtBlock#s | CODE.ExpStmt#s | CODE.Return#s | CODE.If#(s) | CODE.While#(s) :
+    case CODE.StmtBlock#s | CODE.ExpStmt#s | CODE.Return#s | CODE.If#(s) | CODE.Else#(s=CODE.If,_) | CODE.While#(s) :
          global_modread(s);
-    case (first rest) | CODE.Nest#(first,rest) | CODE.For#(first,rest,_) | CODE.Loop#(_,first,rest,_) | CODE.Loop_r#(_,first,rest,_):
+    case (first rest) | CODE.Nest#(first,rest) | CODE.For#(first,rest,_) | CODE.Loop#(_,first,rest,_) | CODE.Loop_r#(_,first,rest,_) :
         local_vars = AppendList[erase_replicate=1](local_vars,collect_local_vars(first));
         (m1,r1)=global_modread(first);
         if (rest != NULL) (m2=_,r2=_)=global_modread(rest);
         else m2=r2=NULL;
         (AppendList[erase_replicate=1](m1,m2),AppendList[erase_replicate=1](r1,r2))
-    case CODE.Else|"" : (NULL,NULL)
+    case CODE.Else|CODE.Macro|"" : (NULL,NULL)
     case CODE.impl_variant#(_,_,s) : global_modread(car s)
     default: (collect_mod(op),collect_global_read[local_vars=local_vars](op))
   }

--- a/lib/analysis.pt
+++ b/lib/analysis.pt
@@ -255,7 +255,7 @@ switch (vars)
          | (op1,op2) | (op1 op2) | CODE.FunctionParameterDecl#(op1,op2):
        BuildList(collect_global_read(op1), collect_global_read(op2))
     case ID|CODE.Name|CODE.ScopedName: if (Lookup(op, local_vars)) { "" } else {op}
-    case STRING|CODE.Break|CODE.EmptyStmt|CODE.SizeOf|CODE.String|INT|CODE.INT_UL|FLOAT|CODE.True|CODE.False|"": ""
+    case STRING|CODE.Break|CODE.EmptyStmt|CODE.SizeOf|CODE.String|INT|CODE.INT_UL|FLOAT|CODE.True|CODE.False|CODE.GotoStmt|CODE.Char|"": ""
     case CODE.DeclStmt#d :
          if (car(d) : CODE.TypeInfo) { collect_global_read(d) } else { "" }
     case CODE.ArrayInit|CODE.TypeName|CODE.TemplateInstantiation|NULL: NULL


### PR DESCRIPTION
This PR address issue #15 . Making update on analysis.p xform.global_modread to handle cases for:
1. StructType
2. Continue and
3. ExpBlock

The current output of these cases above are:
1. Error: no matching case found for: StructType#("compat_ipt_entry","")
2. Error: no matching case found for: Continue, and
3. Error: no matching case found for: ExpBlock#((Bop#(":","net","net")  respectively