### PR TITLE
Feat function decl

### DIFF
--- a/lib/ExpStmt.incl
+++ b/lib/ExpStmt.incl
@@ -64,7 +64,7 @@ Type Processing
 rebuild=(
    if (symtab : "") {
       enter_block("NEW");
-      foreach p = CODE.TypeInfo#(t=_,v=_,_) \in (params body) do
+      foreach p = CODE.TypeInfo#(t=_,v=_,_) \in params do
          insert_typeInfo(t,v);
       enddo
       FunctionDecl[symtab=exit_block()]#(name,params,ret,body)

--- a/lib/ExpStmt.incl
+++ b/lib/ExpStmt.incl
@@ -60,7 +60,18 @@ Type Processing
 <code DeclStmt pars=(decl) /> 
 <code StmtBlock pars=(stmts) symtab="" /> 
 <code DeclarationBlock pars=(stmts) symtab="" /> 
-<code FunctionDecl pars=(name,params,ret,body) symtab="" /> 
+<code FunctionDecl pars=(name,params,ret,body) symtab="" 
+rebuild=(
+   if (symtab : "") {
+      enter_block("NEW");
+      foreach p = CODE.TypeInfo \in params do 
+         insert_typeInfo(p);
+      enddo
+      FunctionDecl[symtab=exit_block()]#(name,params,ret,body)
+   } else {
+      FunctionDecl[symtab=symtab]#(name,params,ret,body)
+   })
+/>
 <code StructBody pars=(stmts) symtab="" />
 
 <***** Variables and declarations ***>

--- a/lib/ExpStmt.incl
+++ b/lib/ExpStmt.incl
@@ -60,18 +60,7 @@ Type Processing
 <code DeclStmt pars=(decl) /> 
 <code StmtBlock pars=(stmts) symtab="" /> 
 <code DeclarationBlock pars=(stmts) symtab="" /> 
-<code FunctionDecl pars=(name,params,ret,body) symtab="" 
-rebuild=(
-   if (symtab : "") {
-      enter_block("NEW");
-      foreach p = CODE.TypeInfo#(t=_,v=_,_) \in (params body) do
-         insert_typeInfo(t,v);
-      enddo
-      FunctionDecl[symtab=exit_block()]#(name,params,ret,body)
-   } else {
-      FunctionDecl[symtab=symtab]#(name,params,ret,body)
-   })
-/>
+<code FunctionDecl pars=(name,params,ret,body) symtab="" />
 <code StructBody pars=(stmts) symtab="" />
 
 <***** Variables and declarations ***>

--- a/lib/ExpStmt.incl
+++ b/lib/ExpStmt.incl
@@ -60,7 +60,18 @@ Type Processing
 <code DeclStmt pars=(decl) /> 
 <code StmtBlock pars=(stmts) symtab="" /> 
 <code DeclarationBlock pars=(stmts) symtab="" /> 
-<code FunctionDecl pars=(name,params,ret,body) symtab="" />
+<code FunctionDecl pars=(name,params,ret,body) symtab="" 
+rebuild=(
+   if (symtab : "") {
+      enter_block("NEW");
+      foreach p = CODE.TypeInfo#(t=_,v=_,_) \in (params body) do
+         insert_typeInfo(t,v);
+      enddo
+      FunctionDecl[symtab=exit_block()]#(name,params,ret,body)
+   } else {
+      FunctionDecl[symtab=symtab]#(name,params,ret,body)
+   })
+/>
 <code StructBody pars=(stmts) symtab="" />
 
 <***** Variables and declarations ***>

--- a/lib/ExpStmt.incl
+++ b/lib/ExpStmt.incl
@@ -64,8 +64,8 @@ Type Processing
 rebuild=(
    if (symtab : "") {
       enter_block("NEW");
-      foreach p = CODE.TypeInfo \in params do 
-         insert_typeInfo(p);
+      foreach p = CODE.TypeInfo#(t=_,v=_,_) \in (params body) do
+         insert_typeInfo(t,v);
       enddo
       FunctionDecl[symtab=exit_block()]#(name,params,ret,body)
    } else {

--- a/lib/analysis.pi
+++ b/lib/analysis.pi
@@ -22,6 +22,8 @@
 
 <xform global_modread pars=(op) local_vars="" output=(_mod,_read) />
 
+<xform collect_all_moderead pars=(op) output=(_mod,_read) />
+
 <* collect all dereferences of ptr that may be modified *>
 <xform collect_ptr_mod pars=(ptr,block) />
 

--- a/lib/analysis.pi
+++ b/lib/analysis.pi
@@ -12,6 +12,10 @@
 
 <xform exit_block pars=(block) tab=GLOBAL.SymTable/>
 
+<xform get_extra_info pars=(variable, tag)/>
+
+<xform set_extra_info pars=(variable, info, tag)/>
+
 <xform get_type pars=(exp) tab=GLOBAL.SymTable/>
 
 <xform global_modread pars=(op) local_vars="" output=(_mod,_read) />

--- a/lib/analysis.pi
+++ b/lib/analysis.pi
@@ -12,9 +12,11 @@
 
 <xform exit_block pars=(block) tab=GLOBAL.SymTable/>
 
-<xform get_extra_info pars=(variable, tag)/>
+<xform get_scope pars=(exp) tab=GLOBAL.SymTable/>
 
-<xform set_extra_info pars=(variable, info, tag)/>
+<xform get_extra_info pars=(variable, tag) tab=GLOBAL.SymTable/>
+
+<xform set_extra_info pars=(variable, info, tag) tab=GLOBAL.SymTable/>
 
 <xform get_type pars=(exp) tab=GLOBAL.SymTable/>
 

--- a/lib/analysis.pt
+++ b/lib/analysis.pt
@@ -195,6 +195,10 @@ switch (vars)
 
 <xform set_extra_info pars=(variable, info, tag) tab=GLOBAL.SymTable>
   scope = get_scope(variable);
+  if(scope == ""){
+    insert_typeInfo(info,variable);
+    scope = get_scope(variable);
+  }
   assert(scope != "");
   if(scope[tag] == ""){
     extra = MAP{};

--- a/lib/analysis.pt
+++ b/lib/analysis.pt
@@ -170,6 +170,34 @@ switch (vars)
   }
 </xform>
 
+<xform get_extra_info pars=(variable, tag)>
+res = NULL;
+scope = exit_block();
+if(scope[tag] == ""){
+  res = "";
+}else{
+  extra = scope[tag];
+  if(extra[variable] == ""){
+    res = "";
+  }else{
+    res = extra[variable];
+  }
+}
+enter_block(scope);
+return res;
+</xform>
+
+<xform set_extra_info pars=(variable, info, tag)>
+scope = exit_block();
+if(scope[tag] == ""){
+  extra = MAP{};
+  scope[tag] = extra;
+}else{
+  extra = scope[tag];
+}
+extra[variable] = info;
+enter_block(scope);
+</xform>
 
 <*******************************************************>
 <xform member_variables pars=(input)>

--- a/lib/analysis.pt
+++ b/lib/analysis.pt
@@ -195,10 +195,6 @@ switch (vars)
 
 <xform set_extra_info pars=(variable, info, tag) tab=GLOBAL.SymTable>
   scope = get_scope(variable);
-  if(scope == ""){
-    insert_typeInfo(info,variable);
-    scope = get_scope(variable);
-  }
   assert(scope != "");
   if(scope[tag] == ""){
     extra = MAP{};

--- a/lib/analysis.pt
+++ b/lib/analysis.pt
@@ -27,6 +27,18 @@ include analysis.pi
    res
 </xform>
 
+<xform get_scope pars=(exp) tab=GLOBAL.SymTable>
+  res = "";
+  for (p = tab; p != NULL; p = cdr(p)){
+    if (car(p) != ""){
+      if ((car(p))[exp] != ""){
+        res = car(p);
+      }
+    }
+  }
+  return res;
+</xform>
+
 <xform insert_typeInfo pars=(type,vars) gtab=GLOBAL.SymTable>
 if (gtab == NULL) { GLOBAL.SymTable=gtab=MAP{}; }
 tab = car(gtab);
@@ -170,33 +182,30 @@ switch (vars)
   }
 </xform>
 
-<xform get_extra_info pars=(variable, tag)>
-res = NULL;
-scope = exit_block();
-if(scope[tag] == ""){
-  res = "";
-}else{
-  extra = scope[tag];
-  if(extra[variable] == ""){
-    res = "";
+<xform get_extra_info pars=(variable, tag) tab=GLOBAL.SymTable>
+  scope = get_scope(variable);
+  assert(scope != "");
+  if(scope[tag] == ""){
+    return "";
   }else{
-    res = extra[variable];
+    extra = scope[tag];
+    return extra[variable];
   }
-}
-enter_block(scope);
-return res;
 </xform>
 
-<xform set_extra_info pars=(variable, info, tag)>
-scope = exit_block();
-if(scope[tag] == ""){
-  extra = MAP{};
-  scope[tag] = extra;
-}else{
+<xform set_extra_info pars=(variable, info, tag) tab=GLOBAL.SymTable>
+  scope = get_scope(variable);
+  assert(scope != "");
+  if(scope[tag] == ""){
+    extra = MAP{};
+    scope[tag] = extra;
+  }
   extra = scope[tag];
-}
-extra[variable] = info;
-enter_block(scope);
+  if(extra[variable] == ""){
+    extra[variable] = info;
+  }else{
+    extra[variable] =  info :: extra[variable];
+  }
 </xform>
 
 <*******************************************************>

--- a/lib/analysis.pt
+++ b/lib/analysis.pt
@@ -253,21 +253,32 @@ switch (vars)
   ops
 </xform>
 
-<xform collect_mod pars=(op) >
+<xform collect_mod pars=(op) scope="">
   switch (op) {
     case CODE.Assign#(lhs, _) | CODE.Uop#("--"|"++",lhs)
        | CODE.VarRef#(lhs,"++"|"--") | CODE.DeleteStmt#(lhs) : lhs
     case INT|CODE.Break | CODE.EmptyStmt | NULL | CODE.True | CODE.False |
-         CODE.DeclStmt | CODE.VariableParse | ID | CODE.Name |
-         CODE.PtrAccess | CODE.ArrayAccess | CODE.Bop | CODE.Uop: NULL
+         CODE.VariableParse | ID | CODE.Name |
+         CODE.PtrAccess | CODE.ArrayAccess | CODE.Bop | CODE.Uop |
+         STRING|CODE.String|CODE.SizeOf|CODE.ObjAccess|CODE.IntType|CODE.IntType1|CODE.PtrType |
+         CODE.INT_UL|CODE.INT_0x|FLOAT|CODE.GotoStmt|CODE.Char|CODE.Return|CODE.Continue|CODE.LabelStmt|"" : NULL
+    case CODE.DeclStmt:
+        res = NULL;
+        if(scope : "all"){
+          foreach (op : CODE.TypeInfo#(t=_,n=_,init=_) : TRUE) {
+            if (!(init : NULL|""))
+              res = n :: res;
+          }
+        }
+        res
     case CODE.FunctionCall#("memset"|"memcpy"|"memmove"|ScopedName#("std" "memset"|"memcpy"|"memmove"),args): car(args)
     case CODE.FunctionCall#("assert"|CODE.ScopedName#("std" "make_pair"),_) : NULL
     case CODE.impl_variant#(_,_,block) : collect_mod(car block)
     case CODE.VEC#(name,_,_,_,_) : name
-    case Nest#(first, second) : AppendList[erase_replicate=1](collect_mod(first), collect_mod(second))
-    case If#(exp) : collect_mod(exp)
-    default: "___UNKNOWN___"
-    <<*     CODE.FunctionCall | <* for now ignores side effects *>
+    case Nest#(first, second)|(first second) : AppendList[erase_replicate=1](collect_mod(first), collect_mod(second))
+    case If#(exp)|CODE.CastExp#(_,exp)|CODE.FunctionCall#(_,exp) : collect_mod(exp)
+    <*default: "___UNKNOWN___"*>
+    <<*CODE.FunctionCall | <* for now ignores side effects *>
    }
 </xform>
 
@@ -292,10 +303,11 @@ switch (vars)
          | (op1,op2) | (op1 op2) | CODE.FunctionParameterDecl#(op1,op2):
        BuildList(collect_global_read(op1), collect_global_read(op2))
     case ID|CODE.Name|CODE.ScopedName: if (Lookup(op, local_vars)) { "" } else {op}
-    case STRING|CODE.Break|CODE.EmptyStmt|CODE.SizeOf|CODE.String|INT|CODE.INT_UL|FLOAT|CODE.True|CODE.False|"": ""
+    case STRING|CODE.Break|CODE.EmptyStmt|CODE.String|INT|CODE.INT_UL|CODE.IntType|FLOAT|CODE.True|CODE.False|CODE.GotoStmt|CODE.Char|CODE.Continue|CODE.LabelStmt|"": ""
+    case CODE.ExpBlock#d|CODE.SizeOf#d|CODE.SizeOfArg#d: collect_global_read(d);
     case CODE.DeclStmt#d :
          if (car(d) : CODE.TypeInfo) { collect_global_read(d) } else { "" }
-    case CODE.ArrayInit|CODE.TypeName|CODE.TemplateInstantiation|NULL: NULL
+    case CODE.ArrayInit|CODE.TypeName|CODE.TemplateInstantiation|CODE.StructType|CODE.FunctionDecl|NULL: NULL
     case CODE.impl_variant#(_,_,block) : collect_global_read(car block)
     case CODE.VEC#(name,_,_,_,_) : name
    }
@@ -325,7 +337,7 @@ switch (vars)
 <xform global_modread pars=(op) local_vars="" output=(_mod,_read) >
   switch (op) {
     case CODE.FunctionDecl#(cur_name,params, rtype, body): global_modread(body)
-    case CODE.StmtBlock#s | CODE.ExpStmt#s | CODE.Return#s | CODE.If#(s) | CODE.While#(s) :
+        case CODE.StmtBlock#s | CODE.ExpStmt#s | CODE.Return#s | CODE.If#(s) | CODE.While#(s) :
          global_modread(s);
     case (first rest) | CODE.Nest#(first,rest) | CODE.For#(first,rest,_) | CODE.Loop#(_,first,rest,_) | CODE.Loop_r#(_,first,rest,_):
         local_vars = AppendList[erase_replicate=1](local_vars,collect_local_vars(first));
@@ -336,6 +348,28 @@ switch (vars)
     case CODE.Else|"" : (NULL,NULL)
     case CODE.impl_variant#(_,_,s) : global_modread(car s)
     default: (collect_mod(op),collect_global_read[local_vars=local_vars](op))
+  }
+</xform>
+
+<xform collect_all_modread pars=(op) output=(_mod,_read) >
+  switch (op) {
+    case CODE.FunctionDecl#(cur_name,params, rtype, body): collect_all_modread(body)
+    case CODE.StmtBlock#s | CODE.ExpStmt#s | CODE.TypeDef#s | CODE.ExternDecl#s | CODE.Return#s | CODE.If#(s) | CODE.Else#(CODE.If#(s=_),_) | CODE.While#(s) :
+         collect_all_modread(s);
+    case (first rest) | CODE.Nest#(first,rest) | CODE.For#(first,rest,_):
+        (m1,r1)=collect_all_modread(first);
+        if (rest != NULL) (m2=_,r2=_)=collect_all_modread(rest);
+        else m2=r2=NULL;
+        (AppendList[erase_replicate=1](m1,m2),AppendList[erase_replicate=1](r1,r2))
+    case  CODE.Loop#(name,start,stop,step) | CODE.Loop_r#(name,start,stop,step) :
+        (m1,r1)=collect_all_modread(name);
+        (m2,r2)=collect_all_modread(start);
+        (m3,r3)=collect_all_modread(stop);
+        (m4,r4)=collect_all_modread(step);
+        (AppendList[erase_replicate=1](m1::m2,m3::m4),AppendList[erase_replicate=1](r1::r2,r3::r4))
+    case CODE.Else|Macro|"" : (NULL,NULL)
+    case CODE.impl_variant#(_,_,s) : collect_all_modread(car s)
+    default: (collect_mod[scope="all"](op),collect_global_read(op))
   }
 </xform>
 

--- a/lib/analysis.pt
+++ b/lib/analysis.pt
@@ -337,7 +337,7 @@ switch (vars)
 <xform global_modread pars=(op) local_vars="" output=(_mod,_read) >
   switch (op) {
     case CODE.FunctionDecl#(cur_name,params, rtype, body): global_modread(body)
-        case CODE.StmtBlock#s | CODE.ExpStmt#s | CODE.Return#s | CODE.If#(s) | CODE.While#(s) :
+    case CODE.StmtBlock#s | CODE.ExpStmt#s | CODE.Return#s | CODE.If#(s) | CODE.While#(s) :
          global_modread(s);
     case (first rest) | CODE.Nest#(first,rest) | CODE.For#(first,rest,_) | CODE.Loop#(_,first,rest,_) | CODE.Loop_r#(_,first,rest,_):
         local_vars = AppendList[erase_replicate=1](local_vars,collect_local_vars(first));


### PR DESCRIPTION
This PR addresses the issue of function parameters and variables declared in a function not found in the global symbol table after entering a function block by changing:

`<code FunctionDecl pars=(name,params,ret,body) symtab="" />`

to 
```
<code FunctionDecl pars=(name,params,ret,body) symtab="" 
rebuild=(
if (symtab : "") {
enter_block("NEW");
foreach p = CODE.TypeInfo \in params do 
insert_typeInfo(p);
enddo
FunctionDecl[symtab=exit_block()]#(name,params,ret,body)
} else {
FunctionDecl[symtab=symtab]#(name,params,ret,body)
}
/>
```