### PR TITLE
Feat extend set extra info

### DIFF
--- a/lib/analysis.pi
+++ b/lib/analysis.pi
@@ -16,7 +16,7 @@
 
 <xform get_extra_info pars=(variable, tag) tab=GLOBAL.SymTable/>
 
-<xform set_extra_info pars=(variable, info, tag) set_new_var=FALSE tab=GLOBAL.SymTable/>
+<xform set_extra_info pars=(variable, info, tag) insert_new_var=FALSE tab=GLOBAL.SymTable/>
 
 <xform set_new_info pars=(variable)/>
 

--- a/lib/analysis.pi
+++ b/lib/analysis.pi
@@ -16,7 +16,9 @@
 
 <xform get_extra_info pars=(variable, tag) tab=GLOBAL.SymTable/>
 
-<xform set_extra_info pars=(variable, info, tag) tab=GLOBAL.SymTable/>
+<xform set_extra_info pars=(variable, info, tag) set_new_var=FALSE tab=GLOBAL.SymTable/>
+
+<xform set_new_info pars=(variable)/>
 
 <xform get_type pars=(exp) tab=GLOBAL.SymTable/>
 

--- a/lib/analysis.pi
+++ b/lib/analysis.pi
@@ -12,6 +12,10 @@
 
 <xform exit_block pars=(block) tab=GLOBAL.SymTable/>
 
+<xform get_extra_info pars=(variable, tag)/>
+
+<xform set_extra_info pars=(variable, info, tag)/>
+
 <xform get_type pars=(exp) tab=GLOBAL.SymTable/>
 
 <xform global_modread pars=(op) local_vars="" output=(_mod,_read) />

--- a/lib/analysis.pi
+++ b/lib/analysis.pi
@@ -12,9 +12,11 @@
 
 <xform exit_block pars=(block) tab=GLOBAL.SymTable/>
 
-<xform get_extra_info pars=(variable, tag)/>
+<xform get_scope pars=(exp) tab=GLOBAL.SymTable/>
 
-<xform set_extra_info pars=(variable, info, tag)/>
+<xform get_extra_info pars=(variable, tag) tab=GLOBAL.SymTable/>
+
+<xform set_extra_info pars=(variable, info, tag) tab=GLOBAL.SymTable/>
 
 <xform get_type pars=(exp) tab=GLOBAL.SymTable/>
 

--- a/lib/analysis.pt
+++ b/lib/analysis.pt
@@ -193,9 +193,9 @@ switch (vars)
   }
 </xform>
 
-<xform set_extra_info pars=(variable, info, tag) set_new_var=FALSE tab=GLOBAL.SymTable>
+<xform set_extra_info pars=(variable, info, tag) insert_new_var=FALSE tab=GLOBAL.SymTable>
   scope = get_scope(variable);
-  if(scope == "" && (set_new_var:TRUE)){
+  if(scope == "" && (insert_new_var:TRUE)){
     set_new_info(variable);
     scope = get_scope(variable);
   }

--- a/lib/analysis.pt
+++ b/lib/analysis.pt
@@ -170,6 +170,34 @@ switch (vars)
   }
 </xform>
 
+<xform get_extra_info pars=(variable, tag)>
+res = NULL;
+scope = exit_block();
+if(scope[tag] == ""){
+  res = "";
+}else{
+  extra = scope[tag];
+  if(extra[variable] == ""){
+    res = "";
+  }else{
+    res = extra[variable];
+  }
+}
+enter_block(scope);
+return res;
+</xform>
+
+<xform set_extra_info pars=(variable, info, tag)>
+scope = exit_block();
+if(scope[tag] == ""){
+  extra = MAP{};
+  scope[tag] = extra;
+}else{
+  extra = scope[tag];
+}
+extra[variable] = info;
+enter_block(scope);
+</xform>
 
 <*******************************************************>
 <xform member_variables pars=(input)>

--- a/lib/analysis.pt
+++ b/lib/analysis.pt
@@ -27,6 +27,18 @@ include analysis.pi
    res
 </xform>
 
+<xform get_scope pars=(exp) tab=GLOBAL.SymTable>
+  res = "";
+  for (p = tab; p != NULL; p = cdr(p)){
+    if (car(p) != ""){
+      if ((car(p))[exp] != ""){
+        res = car(p);
+      }
+    }
+  }
+  return res;
+</xform>
+
 <xform insert_typeInfo pars=(type,vars) gtab=GLOBAL.SymTable>
 if (gtab == NULL) { GLOBAL.SymTable=gtab=MAP{}; }
 tab = car(gtab);
@@ -170,33 +182,30 @@ switch (vars)
   }
 </xform>
 
-<xform get_extra_info pars=(variable, tag)>
-res = NULL;
-scope = exit_block();
-if(scope[tag] == ""){
-  res = "";
-}else{
-  extra = scope[tag];
-  if(extra[variable] == ""){
-    res = "";
+<xform get_extra_info pars=(variable, tag) tab=GLOBAL.SymTable>
+  scope = get_scope(variable);
+  assert(scope != "");
+  if(scope[tag] == ""){
+    return "";
   }else{
-    res = extra[variable];
+    extra = scope[tag];
+    return extra[variable];
   }
-}
-enter_block(scope);
-return res;
 </xform>
 
-<xform set_extra_info pars=(variable, info, tag)>
-scope = exit_block();
-if(scope[tag] == ""){
-  extra = MAP{};
-  scope[tag] = extra;
-}else{
+<xform set_extra_info pars=(variable, info, tag) tab=GLOBAL.SymTable>
+  scope = get_scope(variable);
+  assert(scope != "");
+  if(scope[tag] == ""){
+    extra = MAP{};
+    scope[tag] = extra;
+  }
   extra = scope[tag];
-}
-extra[variable] = info;
-enter_block(scope);
+  if(extra[variable] == ""){
+    extra[variable] = info;
+  }else{
+    extra[variable] =  info :: extra[variable];
+  }
 </xform>
 
 <*******************************************************>

--- a/lib/analysis.pt
+++ b/lib/analysis.pt
@@ -193,8 +193,12 @@ switch (vars)
   }
 </xform>
 
-<xform set_extra_info pars=(variable, info, tag) tab=GLOBAL.SymTable>
+<xform set_extra_info pars=(variable, info, tag) set_new_var=FALSE tab=GLOBAL.SymTable>
   scope = get_scope(variable);
+  if(scope == "" && (set_new_var:TRUE)){
+    set_new_info(variable);
+    scope = get_scope(variable);
+  }
   assert(scope != "");
   if(scope[tag] == ""){
     extra = MAP{};
@@ -206,6 +210,11 @@ switch (vars)
   }else{
     extra[variable] =  info :: extra[variable];
   }
+</xform>
+
+<xform set_new_info pars=(variable) gtab=GLOBAL.SymTable>
+  tab = car(gtab);
+  if (tab != "")tab[variable]=NULL;
 </xform>
 
 <*******************************************************>


### PR DESCRIPTION
This PR seeks to extend set_extra_info as follows:

- add an optional input parameter set_new_var
- when set_new_var is TRUE, and the required input `_variable_` is not in the symbol table
- call set_new_info to add the variable to the symbol table