### PR TITLE
Add pre-push hooks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -37,7 +37,7 @@ test -n "$rose_srcdir" || rose_srcdir="";
 test -n "$atlas_exe" || atlas_exe=xdmmtst;
 test -e "$atlas_obj" && atlas_inc="${atlas_obj}/Make.inc";
 
-testdirs="commands gemmATLAS gemvATLAS gerATLAS autoScripts timerGeneration parseF parseC parsePy tune"; 
+testdirs="commands gemmATLAS gemvATLAS gerATLAS autoScripts timerGeneration parseF parseC tune"; 
 #tooldirs="highlevel_interface test_files auto_tuning matrixOpt stencil-codegen splash2Prof";
 tooldirs="";
 

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,0 +1,53 @@
+#!/bin/sh
+
+# Called by "git push" after it has checked the remote status, 
+# but before anything has been pushed.  
+# If this script exits with a non-zero status nothing will be pushed.
+#
+# This hook is called with the following parameters:
+#
+# $1 -- Name of the remote to which the push is being done
+# $2 -- URL to which the push is being done
+#
+# If pushing without using a named remote those arguments will be equal.
+#
+# Information about the commits which are being pushed is supplied as lines to
+# the standard input in the form:
+#
+#   <local ref> <local oid> <remote ref> <remote oid>
+#
+
+remote="$1"
+url="$2"
+
+zero=$(git hash-object --stdin </dev/null | tr '[0-9a-f]' '0')
+
+while read local_ref local_oid remote_ref remote_oid
+do
+	if test "$local_oid" = "$zero"
+	then
+		# Handle delete
+		continue
+	else
+		if test "$remote_oid" = "$zero"
+		then
+			# New branch, examine all commits
+			range="$local_oid"
+		else
+			# Update to existing branch, examine new commits
+			range="$remote_oid..$local_oid"
+		fi
+
+		# Run the tests
+    make check
+
+    # Stop iterating if error
+    if [ $? -ne 0 ]
+    then
+      echo -e "Aborting push: make test failed"
+      exit 1
+    fi
+	fi
+done
+
+exit 0

--- a/src/poet_yacc.y
+++ b/src/poet_yacc.y
@@ -51,7 +51,7 @@ OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGEN
 OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISEDOF THE POSSIBILITY OF SUCH DAMAGE.
 */
 /*********************************************************************/
-/*  Yacc parser for reading POET specefications and building AST     */
+/*  Yacc parser for reading POET specifications and building AST     */
 /*********************************************************************/
 #define YYDEBUG 1
 #define YYERROR_VERBOSE
@@ -59,6 +59,8 @@ OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISE
 #include <assert.h>
 
 YaccState yaccState;
+int yylex();
+void yyerror(const char *);
 
 extern void* insert_input();
 extern void set_input_debug();


### PR DESCRIPTION
This PR's main goal is to add a pre-push hook to enforce "make check" tests to pass before one is able to push to the remote. 

In order to be able to push this PR to remote I had to:
* disable the tests for parsePy (referenced in issue #26)
* added 2 required function declarations in poet_yacc.y to address a build error in C99

To test the pre-push hook in this PR, please follow these steps:
1. `checkout feat-add-hooks`
2. edit to add: might want to fork the repo and experiment on a forked version for the following steps
3. checkout a new branch (based on feat-add-hooks so you get the hook)
4. might require rebuilding POET depending on your system
5. update git's default hooks directory (local only to this repository) with:
  * `find .git/hooks -type l -exec rm {} \;` //removes any already existing symlinks
  * `find hooks -type f -exec ln -sf ../../{} .git/hooks/ \;` //creates a symlink to hooks/pre-push
6. make a small test change and commit
  * for example, to see the pre-push hook rejecting pushes when make check doesn't pass, one can add `parsePy` to `testdirs` in `configure.ac` to re-enable parsePy tests
7. `git push` --> this should push if tests pass

Future developments
* I'd like to add a script to run during build so that the user does not have to manually create symlinks mentioned previously in step 3
* Users are still able to bypass this hook by using `git push --no-verify` so we still need a server-side hook (Github actions?)