### PR TITLE
Fix Uop in collect_global_read

### DIFF
--- a/lib/analysis.pt
+++ b/lib/analysis.pt
@@ -283,10 +283,9 @@ switch (vars)
      case  CODE.FunctionCall#(_,rhs) | CODE.FunctionCallParameter#(rhs) | CODE.VarConstructor#rhs | DeleteStmt#(rhs) |
            CODE.TypeInfo#(_,_,rhs) | CODE.VarInit#(rhs) | CODE.NewAlloc#(_,rhs) |
            CODE.ArraySubscript#rhs | CODE.CastExp#(_,rhs) | CODE.Return#(rhs) |
-           CODE.Uop#("!"|"*"|"++"|"--"|"&",rhs) | CODE.VarRef#(rhs,"++"|"--"):
+           CODE.Uop#("!"|"*"|"++"|"--"|"&"|"-"|"+"|"~",rhs) | CODE.VarRef#(rhs,"++"|"--"):
          collect_global_read(rhs)
-     case CODE.PtrAccess#(rhs=_,_) | CODE.Bop#(".",rhs=_,_) | CODE.Uop#("*",rhs=_)
-         | CODE.ObjAccess#(rhs=_,_)  | CODE.ArrayAccess#(_,rhs=_) | CODE.Uop#(_,rhs=_):
+     case CODE.PtrAccess#(rhs=_,_) | CODE.Bop#(".",rhs=_,_) | CODE.ObjAccess#(rhs=_,_) | CODE.ArrayAccess#(_,rhs=_):
          BuildList(collect_global_read(rhs), op)
      case CODE.Assign#(op1,op2):
          switch (op1) {

--- a/lib/analysis.pt
+++ b/lib/analysis.pt
@@ -283,9 +283,10 @@ switch (vars)
      case  CODE.FunctionCall#(_,rhs) | CODE.FunctionCallParameter#(rhs) | CODE.VarConstructor#rhs | DeleteStmt#(rhs) |
            CODE.TypeInfo#(_,_,rhs) | CODE.VarInit#(rhs) | CODE.NewAlloc#(_,rhs) |
            CODE.ArraySubscript#rhs | CODE.CastExp#(_,rhs) | CODE.Return#(rhs) |
-           CODE.Uop#("!"|"*"|"++"|"--"|"&"|"-"|"+"|"~",rhs) | CODE.VarRef#(rhs,"++"|"--"):
+           CODE.Uop#("!"|"++"|"--"|"&"|"-"|"+"|"~",rhs) | CODE.VarRef#(rhs,"++"|"--"):
          collect_global_read(rhs)
-     case CODE.PtrAccess#(rhs=_,_) | CODE.Bop#(".",rhs=_,_) | CODE.ObjAccess#(rhs=_,_) | CODE.ArrayAccess#(_,rhs=_):
+     case CODE.PtrAccess#(rhs=_,_) | CODE.Bop#(".",rhs=_,_) | CODE.Uop#("*",rhs=_)
+         | CODE.ObjAccess#(rhs=_,_)  | CODE.ArrayAccess#(_,rhs=_):
          BuildList(collect_global_read(rhs), op)
      case CODE.Assign#(op1,op2):
          switch (op1) {

--- a/test/libFunctions/test_collect_global_read_uop.pt
+++ b/test/libFunctions/test_collect_global_read_uop.pt
@@ -1,0 +1,44 @@
+include analysis.pi
+
+<eval
+<**** Uop#("-",_), where input is `return XT_ALIGN(target->targetsize) - COMPAT_XT_ALIGN(csize);` ****>
+result1 = collect_global_read(Return#(Bop#("+",FunctionCall#("XT_ALIGN", PtrAccess#("target","targetsize")), 
+                                                    Uop#("-",FunctionCall#( "COMPAT_XT_ALIGN","csize")))));
+expected_output1 = (("target"PtrAccess#("target","targetsize")) "csize");
+assert(expected_output1 : result1);
+
+<**** Uop#("+",_), where input is `return +x;` ****>
+result2 = collect_global_read(Return#(Uop#("+","x")));
+expected_output2 = ("x");
+assert(expected_output2 : result2);
+
+<**** Uop#("~",_), where input is `return ~num;` ****>
+result3 = collect_global_read(Return#(Uop#("~","num")));
+expected_output3 = ("num");
+assert(expected_output3 : result3);
+
+<**** Uop#("++",_), where input is `return ++count;` ****>
+result4 = collect_global_read(Return#(Uop#("++","count")));
+expected_output4 = ("count");
+assert(expected_output4 : result4);
+
+<**** Uop#("--",_), where input is `return --count;` ****>
+result5 = collect_global_read(Return#(Uop#("--","count")));
+expected_output5 = ("count");
+assert(expected_output5 : result5);
+
+<**** Uop#("*",_), where input is `int value = *ptr;` ****>
+result6 = collect_global_read(DeclStmt#(TypeInfo#(IntType#("int"),"value",VarInit#(Uop#("*","ptr")))));
+expected_output6 = ("ptr");
+assert(expected_output6 : result6);
+
+<**** Uop#("!",_), where input is `int isFalse = !isTrue;` ****>
+result7 = collect_global_read(DeclStmt#(TypeInfo#(IntType#("int"),"isFalse",VarInit#(Uop#("!","isTrue")))));
+expected_output7 = ("isTrue");
+assert(expected_output7 : result7);
+
+<**** Uop#("&",_), where input is `int* ptr = &x;` ****>
+result8 = collect_global_read(DeclStmt#(TypeInfo#(PtrType#(IntType#("int")),"ptr",VarInit#(Uop#("&","x")))));
+expected_output8 = ("x");
+assert(expected_output8 : result8);
+/>

--- a/test/libFunctions/test_collect_global_read_uop.pt
+++ b/test/libFunctions/test_collect_global_read_uop.pt
@@ -29,7 +29,7 @@ assert(expected_output5 : result5);
 
 <**** Uop#("*",_), where input is `int value = *ptr;` ****>
 result6 = collect_global_read(DeclStmt#(TypeInfo#(IntType#("int"),"value",VarInit#(Uop#("*","ptr")))));
-expected_output6 = ("ptr");
+expected_output6 = ("ptr"Uop#("*","ptr"));
 assert(expected_output6 : result6);
 
 <**** Uop#("!",_), where input is `int isFalse = !isTrue;` ****>


### PR DESCRIPTION
This PR fixes issue #33 by removing case: CODE.Uop#(,rhs=) and enumerate all Uop (by adding CODE.Uop#(.. "-"|"+"|"~",rhs).