### PR TITLE
Add CODE.ArrayAccess case to collect_variable_defuse

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -22,6 +22,7 @@ AC_CONFIG_FILES([test/tune/Makefile])
 AC_CONFIG_FILES([examples/Makefile])
 AC_CONFIG_FILES([test/parseC/Makefile])
 AC_CONFIG_FILES([test/parsePy/Makefile])
+AC_CONFIG_FILES([test/libFunctions/Makefile])
 AC_CONFIG_FILES([tools/Makefile])
 #AC_CONFIG_FILES([tools/highlevel_interface/Makefile])
 #AC_CONFIG_FILES([tools/test_files/Makefile])
@@ -37,7 +38,7 @@ test -n "$rose_srcdir" || rose_srcdir="";
 test -n "$atlas_exe" || atlas_exe=xdmmtst;
 test -e "$atlas_obj" && atlas_inc="${atlas_obj}/Make.inc";
 
-testdirs="commands gemmATLAS gemvATLAS gerATLAS autoScripts timerGeneration parseF parseC tune"; 
+testdirs="commands gemmATLAS gemvATLAS gerATLAS autoScripts timerGeneration parseF parseC tune libFunctions"; 
 #tooldirs="highlevel_interface test_files auto_tuning matrixOpt stencil-codegen splash2Prof";
 tooldirs="";
 

--- a/lib/analysis.pt
+++ b/lib/analysis.pt
@@ -555,7 +555,7 @@ switch (vars)
            }
         }
         else { (NULL, NULL, found_stmt, stop2) }
-  case CODE.FunctionCall#(_,e)|(e=CODE.Bop|CODE.Uop)|CODE.VarInit#e:
+  case CODE.FunctionCall#(_,e)|(e=CODE.Bop|CODE.Uop|CODE.ArrayAccess)|CODE.VarInit#e:
         if (dir == "def") { (NULL, NULL, 0, 0) }
         else if (Lookup(var, e))
           { (found_stmt)? (NULL,input,0,0) : (input, NULL,0,0) }

--- a/test/libFunctions/Makefile.am
+++ b/test/libFunctions/Makefile.am
@@ -1,0 +1,17 @@
+
+INPUT = 
+OUTPUT= 
+POET_LIB=$(top_srcdir)/lib
+pcg = ${top_builddir}/src/pcg
+DEBUG_FLAG=
+
+
+all : defuse_array_access
+
+defuse_array_access :
+	$(pcg) $(DEBUG_FLAG) -L$(POET_LIB) -pinputFile=input_defuse_arrayaccess.c -poutfile=out test_defuse_arrayaccess.pt
+
+
+check: 
+	make defuse_array_access
+	

--- a/test/libFunctions/input_defuse_arrayaccess.c
+++ b/test/libFunctions/input_defuse_arrayaccess.c
@@ -1,0 +1,9 @@
+static bool pop(struct jsonparse_state *state)
+{
+  if(state->depth == 0) {
+    return false;
+  }
+  state->depth--;
+  state->vtype = state->stack[state->depth];
+  return true;
+}

--- a/test/libFunctions/test_defuse_arrayaccess.pt
+++ b/test/libFunctions/test_defuse_arrayaccess.pt
@@ -1,0 +1,48 @@
+include analysis.pi
+
+<************************************************************
+Define input command line parameters
+*************************************************************>
+<parameter inputFile default="" message="input file name" />
+<************************************************************
+Parse inputFile & headerFile
+*************************************************************>
+<input from=inputFile syntax="Cfront.code" to=inputCode/>
+
+<eval
+<**** get the function input to test - pop() ****>
+input_function = NULL;
+foreach cur_func = CODE.FunctionDecl \in inputCode do
+  input_function = cur_func;
+	break;
+enddo;
+
+<************************************************************
+TEST 1 - collect_variable_uses(var, stmt, input)
+Input = var = state->depth - variable to find uses
+        stmt = state->depth--; - statement where variable state->depth is defined
+        input = pop();  - function containing stmt
+Output = List of some statements using state->depth after stmt.
+        (
+          state->vtype = state->stack[state->depth];
+        )
+*************************************************************>
+result1 = XFORM.collect_variable_uses(PtrAccess#("state","depth"), ExpStmt#(VarRef#(PtrAccess#("state","depth"),"--")), input_function);
+
+expected_output1 = ExpStmt#(
+      Assign#(PtrAccess#("state","vtype"),
+      ArrayAccess#(PtrAccess#("state","stack"),PtrAccess#("state","depth"))));
+
+assert(expected_output1 : result1);
+
+<************************************************************
+TEST 2 - collect_variable_uses(var, stmt, input)
+Input = var = state->vtype - variable to find uses
+        stmt = state->depth--; - statement where variable state->vtype is defined
+        input = pop();  - function containing stmt
+Output = NULL
+*************************************************************>
+result2 = XFORM.collect_variable_uses(PtrAccess#("state","vtype"), ExpStmt#(VarRef#(PtrAccess#("state","depth"),"--")), input_function);
+
+assert(result2 : NULL);
+/>


### PR DESCRIPTION
This PR adds CODE.ArrayAccess to collect_variable_defuse()

### Example:
`To get the use of state->depth in this statement as input: state->vtype = state->stack[state->depth], we need to add a case that handles ArrayAccess, it currently goes to default.`