### PR TITLE
Feat calculate new pos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,54 @@
-**/*.so
-**/*.o
+# Autotools
+Makefile.in
+/ar-lib
+/mdate-sh
+/py-compile
+/test-driver
+/ylwrap
+.deps/
+.dirstamp
+autom4te.cache
+/autoscan.log
+/autoscan-*.log
+/aclocal.m4
+/compile
+/config.cache
+/config.guess
+/config.h.in
+/config.log
+/config.status
+/config.sub
+/configure
+/configure.scan
+/depcomp
+/install-sh
+/missing
+/stamp-h1
+/ltmain.sh
+/texinfo.tex
+m4/libtool.m4
+m4/ltoptions.m4
+m4/ltsugar.m4
+m4/ltversion.m4
+m4/lt~obsolete.m4
+Makefile
+
+# POET build
 src/pcg
-**/*Makefile
-**/*Makefile.in
-configure
-aclocal.m4
+*.o
+src/poet_lex.c
+src/poet_yacc.c
+src/poet_yacc.h
+src/poet_yacc.output
+src/libpoet.a
+
+# Tex build
+doc/*.aux
+doc/*.idx
+doc/*.log
+doc/*.toc
+doc/*.out
+
+# Testfiles
+# For SMT solver
+*.smt

--- a/lib/DataStructureMatch.pt
+++ b/lib/DataStructureMatch.pt
@@ -2,8 +2,9 @@ include utils.incl
 
 <xform GenDataMatchSpecification pars=(anchors, org_spec, impl_spec)>
   CODE.OpSpec#(org_in, org_out) = org_spec;
-  GraphSpec#(new_pos, org_nextto_out, org_reach_out, org_alias_out) = org_out;
+  GraphSpec#(org_nodes_out, org_nextto_out, org_reach_out, org_alias_out) = org_out;
   GraphSpec#(org_nodes_in, org_nextto_in, org_reach_in, org_alias_in) = org_in;
+  new_pos = XFORM.SubstractList(org_nodes_in, org_nodes_out);
   org_nodes = AppendList[erase_replicate=1](org_nodes_in, new_pos);
 
   pos_variables = NULL;

--- a/lib/DataStructureMatch.pt
+++ b/lib/DataStructureMatch.pt
@@ -5,6 +5,7 @@ include utils.incl
   GraphSpec#(org_nodes_out, org_nextto_out, org_reach_out, org_alias_out) = org_out;
   GraphSpec#(org_nodes_in, org_nextto_in, org_reach_in, org_alias_in) = org_in;
   new_pos = XFORM.SubstractList(org_nodes_in, org_nodes_out);
+  print("new_pos " new_pos);
   org_nodes = AppendList[erase_replicate=1](org_nodes_in, new_pos);
 
   pos_variables = NULL;

--- a/lib/DataStructureMatch.pt
+++ b/lib/DataStructureMatch.pt
@@ -5,7 +5,6 @@ include utils.incl
   GraphSpec#(org_nodes_out, org_nextto_out, org_reach_out, org_alias_out) = org_out;
   GraphSpec#(org_nodes_in, org_nextto_in, org_reach_in, org_alias_in) = org_in;
   new_pos = XFORM.SubstractList(org_nodes_in, org_nodes_out);
-  print("new_pos " new_pos);
   org_nodes = AppendList[erase_replicate=1](org_nodes_in, new_pos);
 
   pos_variables = NULL;

--- a/lib/utils.incl
+++ b/lib/utils.incl
@@ -313,6 +313,21 @@ else {
 </xform>
 
 <****** 
+  Substracts list2 from list1 s.t.
+  list1 - list2 = x | x \in list1 and x not \in list2
+*******>
+<xform SubstractList pars=(list1, list2)>
+  res = NULL;
+  for (p_list = list1; p_list != NULL; p_list = TAIL(p_list)) {
+    cur = HEAD(p_list);
+    if(!(XFORM.Lookup(cur, list2))){
+      res = XFORM.AppendList(cur, res);
+    }
+  }
+  return res;
+</xform>
+
+<****** 
 *******>
 <xform gen_cartesian_product pars=(op, l1,l2) >
   res=NULL;

--- a/lib/utils.incl
+++ b/lib/utils.incl
@@ -313,17 +313,26 @@ else {
 </xform>
 
 <****** 
-  Substracts list2 from list1 s.t.
-  list1 - list2 = x | x \in list1 and x not \in list2
+  Enumerate items that are in list1 or list2
+  but not both
 *******>
 <xform SubstractList pars=(list1, list2)>
   res = NULL;
+  
   for (p_list = list1; p_list != NULL; p_list = TAIL(p_list)) {
     cur = HEAD(p_list);
     if(!(XFORM.Lookup(cur, list2))){
       res = XFORM.AppendList(cur, res);
     }
   }
+
+  for (p_list = list2; p_list != NULL; p_list = TAIL(p_list)) {
+    cur = HEAD(p_list);
+    if(!(XFORM.Lookup(cur, list1))){
+      res = XFORM.AppendList(cur, res);
+    }
+  }
+
   return res;
 </xform>
 

--- a/test/SMT/test1.pt
+++ b/test/SMT/test1.pt
@@ -4,10 +4,10 @@ include SMT.code
 <eval 
   queue_pop_spec = CODE.OpSpec#( 
                 CODE.GraphSpec#(("p0" "p1" "pn"), NextTo#("p0", "p1"), ReachableTo#("p1", "pn"), (Alias#("begin","p0") Alias#("back", "pn"))), 
-                CODE.GraphSpec#(NULL, NULL, ReachableTo#("p1", "pn"), (Alias#("begin", "p1") Alias#("back","pn"))));
+                CODE.GraphSpec#(("p1" "pn"), NULL, ReachableTo#("p1", "pn"), (Alias#("begin", "p1") Alias#("back","pn"))));
   queue_push_spec = CODE.OpSpec#(
                 CODE.GraphSpec#(("p0" "pn"), NULL, ReachableTo#("p0", "pn"), (Alias#("begin","p0") Alias#("back", "pn"))), 
-                CODE.GraphSpec#(("pm"), NextTo#("pn", "pm"), ReachableTo#("p0", "pn"), (Alias#("begin", "p0") Alias#("back","pm"))));
+                CODE.GraphSpec#(("p0" "pn" "pm"), NextTo#("pn", "pm"), ReachableTo#("p0", "pn"), (Alias#("begin", "p0") Alias#("back","pm"))));
   push_impl_spec1 = CODE.OpSpec#(
                 GraphSpec#(("p0"), NULL, NULL, (Alias#("head", "null") Alias#("end", "null"))),
                   GraphSpec#(("p_new"), NULL, NULL, (Alias#("head", "p_new") Alias#("end","p_new"))));

--- a/test/libFunctions/Makefile.am
+++ b/test/libFunctions/Makefile.am
@@ -11,6 +11,8 @@ all : defuse_array_access
 defuse_array_access :
 	$(pcg) $(DEBUG_FLAG) -L$(POET_LIB) -pinputFile=input_defuse_arrayaccess.c -poutfile=out test_defuse_arrayaccess.pt
 
+substract_list :
+	$(pcg) $(DEBUG_FLAG) -L$(POET_LIB) test_substract_list.pt
 
 check: 
 	make defuse_array_access

--- a/test/libFunctions/Makefile.am
+++ b/test/libFunctions/Makefile.am
@@ -6,7 +6,7 @@ pcg = ${top_builddir}/src/pcg
 DEBUG_FLAG=
 
 
-all : defuse_array_access
+all : defuse_array_access substract_list
 
 defuse_array_access :
 	$(pcg) $(DEBUG_FLAG) -L$(POET_LIB) -pinputFile=input_defuse_arrayaccess.c -poutfile=out test_defuse_arrayaccess.pt

--- a/test/libFunctions/test_substract_list.pt
+++ b/test/libFunctions/test_substract_list.pt
@@ -1,0 +1,32 @@
+include utils.incl
+
+<eval 
+  list1 = ("A" "B" "C");
+  list2 = ("B" "C" "D");
+  res = XFORM.SubstractList(list1, list2);
+  assert(XFORM.Lookup("A", res));
+
+  list1 = ("A" "B" "C");
+  list2 = ("D" "E" "F");
+  res = XFORM.SubstractList(list1, list2);
+  assert(XFORM.Lookup("A", res));
+  assert(XFORM.Lookup("B", res));
+  assert(XFORM.Lookup("C", res));
+
+  list1 = ("A" "B" "C");
+  list2 = ("A" "B" "C");
+  res = XFORM.SubstractList(list1, list2);
+  assert(res : NULL);
+
+  list1 = ("A" "B" "C");
+  list2 = (NULL);
+  res = XFORM.SubstractList(list1, list2);
+  assert(XFORM.Lookup("A", res));
+  assert(XFORM.Lookup("B", res));
+  assert(XFORM.Lookup("C", res));
+
+  list1 = (NULL);
+  list2 = ("A" "B" "C");
+  res = XFORM.SubstractList(list1, list2);
+  assert(res : NULL);
+/>

--- a/test/libFunctions/test_substract_list.pt
+++ b/test/libFunctions/test_substract_list.pt
@@ -5,6 +5,7 @@ include utils.incl
   list2 = ("B" "C" "D");
   res = XFORM.SubstractList(list1, list2);
   assert(XFORM.Lookup("A", res));
+  assert(XFORM.Lookup("D", res));
 
   list1 = ("A" "B" "C");
   list2 = ("D" "E" "F");
@@ -12,6 +13,9 @@ include utils.incl
   assert(XFORM.Lookup("A", res));
   assert(XFORM.Lookup("B", res));
   assert(XFORM.Lookup("C", res));
+  assert(XFORM.Lookup("D", res));
+  assert(XFORM.Lookup("E", res));
+  assert(XFORM.Lookup("F", res));
 
   list1 = ("A" "B" "C");
   list2 = ("A" "B" "C");
@@ -28,5 +32,7 @@ include utils.incl
   list1 = (NULL);
   list2 = ("A" "B" "C");
   res = XFORM.SubstractList(list1, list2);
-  assert(res : NULL);
+  assert(XFORM.Lookup("A", res));
+  assert(XFORM.Lookup("B", res));
+  assert(XFORM.Lookup("C", res));
 />


### PR DESCRIPTION
Two changes are introduced in this PR:

- A new helper function added to `utils.incl` which subtracts a list from another. For example, if we have `list1 = ("a" "b" "c")` and `list2 = ("b" "c")`, return `("a")`. Some simple testcases are also added to `test/libFunctions`

- In `DataStructureMatch.pt`, the user needed to provide `new_pos` from the output organization. This is updated so that we calculate the `new_pos` in `DataStructureMatch.pt` and the user can just provide the list of position variables instead of only any new positions. 